### PR TITLE
feat: Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Python CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Install dependencies
+      run: |
+        uv sync --system-site-packages
+
+    - name: Lint with ruff
+      run: |
+        uv run ruff check src tests
+        uv run ruff format --check src tests
+
+    - name: Type check with mypy
+      run: |
+        uv run mypy src
+
+    - name: Test with pytest
+      run: |
+        uv run pytest tests/
+
+    - name: Check for Groq API Key
+      env:
+        GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      run: |
+        if [ -z "$GROQ_API_KEY" ]; then
+          echo "Warning: GROQ_API_KEY is not set. Some tests might be skipped or fail."
+          echo "Consider adding it to your repository secrets for full test coverage."
+        else
+          echo "GROQ_API_KEY is set."
+        fi

--- a/README.md
+++ b/README.md
@@ -391,6 +391,19 @@ tests/
 └── test_integration.py             # 統合テスト
 ```
 
+##  CI/CD
+
+This project uses GitHub Actions for Continuous Integration. The workflow is defined in `.github/workflows/ci.yml`.
+
+The CI pipeline performs the following checks on every push and pull request:
+- Lints the code using Ruff (`ruff check` and `ruff format --check`).
+- Performs static type checking using mypy (`mypy src`).
+- Runs tests using pytest (`pytest tests/`).
+
+These checks are performed across multiple Python versions (3.10, 3.11, 3.12) to ensure compatibility.
+
+**Note on `GROQ_API_KEY`**: The core functionality of this project relies on the Groq API. While the tests are designed to run, some might be skipped or might not fully reflect real-world behavior if the `GROQ_API_KEY` is not available as a repository secret. For comprehensive testing in your own fork or environment, ensure this secret is configured.
+
 ## 🤝 コントリビューション
 
 ### プルリクエストガイドライン


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow for Continuous Integration.

The pipeline performs the following steps:
- Lints the code with Ruff.
- Type checks with mypy.
- Runs tests with pytest.

These checks are executed on Python versions 3.10, 3.11, and 3.12.

Documentation for the CI/CD setup has been added to the README.md.